### PR TITLE
Dives deeper into mount integration

### DIFF
--- a/scheduler/src/cook/components.clj
+++ b/scheduler/src/cook/components.clj
@@ -74,7 +74,7 @@
                    (route/not-found "<h1>Not a valid route</h1>")))})
 
 (def mesos-scheduler
-  {:mesos-scheduler (fnk [[:settings executor fenzo-fitness-calculator fenzo-floor-iterations-before-reset
+  {:mesos-scheduler (fnk [[:settings fenzo-fitness-calculator fenzo-floor-iterations-before-reset
                            fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback
                            good-enough-fitness hostname mea-culpa-failure-limit mesos-failover-timeout mesos-framework-name
                            mesos-gpu-enabled mesos-leader-path mesos-master mesos-master-hosts mesos-principal
@@ -96,7 +96,6 @@
                           (Class/forName "org.apache.mesos.Scheduler")
                           ((util/lazy-load-var 'cook.mesos/start-mesos-scheduler)
                             {:curator-framework curator-framework
-                             :executor-config executor
                              :fenzo-config {:fenzo-max-jobs-considered fenzo-max-jobs-considered
                                             :fenzo-scaleback fenzo-scaleback
                                             :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn

--- a/scheduler/src/cook/config.clj
+++ b/scheduler/src/cook/config.clj
@@ -58,7 +58,6 @@
                              "com.netflix.fenzo.TaskScheduler" :warn
                              "com.netflix.fenzo.AssignableVirtualMachine" :warn}}))
   ([{:keys [file] :or {file "log/cook.log"} {:keys [default] :or {default :info} :as overrides} :levels}]
-   (println "Initializing logging")
    (try
      (-> (Logger/getRootLogger) .getLoggerRepository .resetConfiguration)
      (let [overrides (->> overrides
@@ -355,7 +354,6 @@
   (try
     (let [literal-config {:config config-map}]
       (pre-configuration literal-config)
-      (.println System/err "Configured logging")
       (log/info "Configured logging")
       (log/info "Cook" @util/version "( commit" @util/commit ")")
       (let [settings {:settings (config-settings literal-config)}]

--- a/scheduler/src/cook/mesos.clj
+++ b/scheduler/src/cook/mesos.clj
@@ -175,8 +175,6 @@
    mea-culpa-failure-limit       -- long, max failures of mea culpa reason before it is considered a 'real' failure
                                     see scheduler/docs/configuration.adoc for more details
    task-constraints              -- map, constraints on task. See scheduler/docs/configuration.adoc for more details
-   executor                      -- cook executor config includes command, default-progress-regex-string, environment,
-                                    log-level, message-length, progress-sample-interval-ms and uri.
    mesos-pending-jobs-atom       -- atom, Populate (and update) list of pending jobs into atom
    offer-cache                   -- atom, map from host to most recent offer. Used to get attributes
    gpu-enabled?                  -- boolean, whether cook will schedule gpus
@@ -185,7 +183,7 @@
    framework-id                  -- str, the Mesos framework id from the cook settings
    fenzo-config                  -- map, config for fenzo, See scheduler/docs/configuration.adoc for more details
    sandbox-syncer-state          -- map, representing the sandbox syncer object"
-  [{:keys [curator-framework executor-config fenzo-config framework-id get-mesos-utilization gpu-enabled? make-mesos-driver-fn
+  [{:keys [curator-framework fenzo-config framework-id get-mesos-utilization gpu-enabled? make-mesos-driver-fn
            mea-culpa-failure-limit mesos-datomic-conn mesos-datomic-mult mesos-leadership-atom mesos-pending-jobs-atom
            mesos-run-as-user offer-cache offer-incubate-time-ms optimizer-config progress-config rebalancer-config
            sandbox-syncer-state server-config task-constraints trigger-chans zk-prefix]}]
@@ -214,7 +212,6 @@
                                         (sched/create-datomic-scheduler
                                          {:conn mesos-datomic-conn
                                           :driver-atom current-driver
-                                          :executor-config executor-config
                                           :fenzo-fitness-calculator fenzo-fitness-calculator
                                           :fenzo-floor-iterations-before-reset fenzo-floor-iterations-before-reset
                                           :fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-warn

--- a/scheduler/src/cook/mesos/scheduler.clj
+++ b/scheduler/src/cook/mesos/scheduler.clj
@@ -787,11 +787,11 @@
 
 (defn- update-match-with-task-metadata-seq
   "Updates the match with an entry for the task metadata for all tasks."
-  [{:keys [tasks] :as match} db framework-id executor-config mesos-run-as-user]
+  [{:keys [tasks] :as match} db framework-id mesos-run-as-user]
   (->> tasks
        ;; sort-by makes task-txns created in matches->task-txns deterministic
        (sort-by (comp :job/uuid :job #(.getRequest ^TaskAssignmentResult %)))
-       (map (partial task/TaskAssignmentResult->task-metadata db framework-id executor-config mesos-run-as-user))
+       (map (partial task/TaskAssignmentResult->task-metadata db framework-id mesos-run-as-user))
        (assoc match :task-metadata-seq)))
 
 (defn- matches->task-txns
@@ -822,8 +822,8 @@
 
 (defn- launch-matched-tasks!
   "Updates the state of matched tasks in the database and then launches them."
-  [matches conn db driver fenzo framework-id executor-config mesos-run-as-user]
-  (let [matches (map #(update-match-with-task-metadata-seq % db framework-id executor-config mesos-run-as-user) matches)
+  [matches conn db driver fenzo framework-id mesos-run-as-user]
+  (let [matches (map #(update-match-with-task-metadata-seq % db framework-id mesos-run-as-user) matches)
         task-txns (matches->task-txns matches)]
     ;; Note that this transaction can fail if a job was scheduled
     ;; during a race. If that happens, then other jobs that should
@@ -876,7 +876,7 @@
 (defn handle-resource-offers!
   "Gets a list of offers from mesos. Decides what to do with them all--they should all
    be accepted or rejected at the end of the function."
-  [conn driver ^TaskScheduler fenzo framework-id executor-config category->pending-jobs-atom mesos-run-as-user
+  [conn driver ^TaskScheduler fenzo framework-id category->pending-jobs-atom mesos-run-as-user
    user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom]
   (log/debug "invoked handle-resource-offers!")
   (let [offer-stash (atom nil)] ;; This is a way to ensure we never lose offers fenzo assigned if an error occurs in the middle of processing
@@ -921,7 +921,7 @@
             (do
               (swap! category->pending-jobs-atom remove-matched-jobs-from-pending-jobs category->job-uuids)
               (log/debug "updated category->pending-jobs:" @category->pending-jobs-atom)
-              (launch-matched-tasks! matches conn db driver fenzo framework-id executor-config mesos-run-as-user)
+              (launch-matched-tasks! matches conn db driver fenzo framework-id mesos-run-as-user)
               (update-host-reservations! rebalancer-reservation-atom matches)
               matched-normal-considerable-jobs-head?)))
         (catch Throwable t
@@ -951,7 +951,7 @@
 (counters/defcounter [cook-mesos scheduler offer-chan-depth])
 
 (defn make-offer-handler
-  [conn driver-atom fenzo framework-id executor-config pending-jobs-atom offer-cache max-considerable scaleback
+  [conn driver-atom fenzo framework-id pending-jobs-atom offer-cache max-considerable scaleback
    floor-iterations-before-warn floor-iterations-before-reset trigger-chan rebalancer-reservation-atom
    mesos-run-as-user]
   (let [chan-length 100
@@ -999,7 +999,7 @@
                                                  (cache/miss c slave-id attrs)))))
                       _ (log/debug "Passing following offers to handle-resource-offers!" offers)
                       user->quota (quota/create-user->quota-fn (d/db conn))
-                      matched-head? (handle-resource-offers! conn @driver-atom fenzo framework-id executor-config pending-jobs-atom mesos-run-as-user @user->usage-future user->quota num-considerable offers-chan offers rebalancer-reservation-atom)]
+                      matched-head? (handle-resource-offers! conn @driver-atom fenzo framework-id pending-jobs-atom mesos-run-as-user @user->usage-future user->quota num-considerable offers-chan offers rebalancer-reservation-atom)]
                   (when (seq offers)
                     (reset! resources-atom (view-incubating-offers fenzo)))
                   ;; This check ensures that, although we value Fenzo's optimizations,
@@ -1615,7 +1615,7 @@
             task-id #(handle-status-update conn driver fenzo sync-agent-sandboxes-fn status)))))))
 
 (defn create-datomic-scheduler
-  [{:keys [conn driver-atom executor-config fenzo-fitness-calculator fenzo-floor-iterations-before-reset
+  [{:keys [conn driver-atom fenzo-fitness-calculator fenzo-floor-iterations-before-reset
            fenzo-floor-iterations-before-warn fenzo-max-jobs-considered fenzo-scaleback framework-id good-enough-fitness
            gpu-enabled? heartbeat-ch mea-culpa-failure-limit mesos-run-as-user offer-cache offer-incubate-time-ms
            pending-jobs-atom progress-config rebalancer-reservation-atom sandbox-syncer-state task-constraints
@@ -1627,7 +1627,7 @@
         fenzo (make-fenzo-scheduler driver-atom offer-incubate-time-ms fenzo-fitness-calculator good-enough-fitness)
         [offers-chan resources-atom]
         (make-offer-handler
-          conn driver-atom fenzo framework-id executor-config pending-jobs-atom offer-cache fenzo-max-jobs-considered
+          conn driver-atom fenzo framework-id pending-jobs-atom offer-cache fenzo-max-jobs-considered
           fenzo-scaleback fenzo-floor-iterations-before-warn fenzo-floor-iterations-before-reset match-trigger-chan
           rebalancer-reservation-atom mesos-run-as-user)
         {:keys [batch-size]} progress-config

--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -17,6 +17,7 @@
   (:require [clojure.data.json :as json]
             [clojure.set :as set]
             [clojure.tools.logging :as log]
+            [cook.config :refer (config)]
             [cook.mesos.util :as util]
             [mesomatic.types :as mtypes]
             [plumbing.core :refer (map-vals)])
@@ -38,12 +39,13 @@
    a. Cook executor has not been explicitly disabled,
    b. This is going to be the first instance of the job, and
    c. The job UUID hash mod 100 yields less than portion percent."
-  [job-ent portion retry-limit]
-  (and (nil? (:job/executor job-ent))
-       (number? retry-limit)
-       (> retry-limit (count (:job/instance job-ent)))
-       (number? portion)
-       (> (* portion 100) (-> job-ent :job/uuid hash (mod 100)))))
+  [job-ent]
+  (let [{:keys [portion retry-limit]} (-> config :settings :executor)]
+    (and (nil? (:job/executor job-ent))
+         (number? retry-limit)
+         (> retry-limit (count (:job/instance job-ent)))
+         (number? portion)
+         (> (* portion 100) (-> job-ent :job/uuid hash (mod 100))))))
 
 (defn use-cook-executor?
   "Returns true if the job should be scheduled to use the Cook executor.
@@ -52,17 +54,19 @@
    2. The Cook executor command has been configured,
    3. Either :job/executor is explicitly enabled
       Or: the job is a cook-executor candidate (see cook-executor-candidate?)."
-  [job-ent {:keys [command portion retry-limit]}]
-  (and (not (use-custom-executor? job-ent))
-       command
-       (or (= :executor/cook (:job/executor job-ent))
-           (cook-executor-candidate? job-ent portion retry-limit))))
+  [job-ent]
+  (let [{:keys [command]} (-> config :settings :executor)]
+    (and (not (use-custom-executor? job-ent))
+         command
+         (or (= :executor/cook (:job/executor job-ent))
+             (cook-executor-candidate? job-ent)))))
 
 (defn build-executor-environment
   "Build the environment for the cook executor."
-  [{:keys [default-progress-regex-string environment log-level max-message-length progress-sample-interval-ms]}
-   job-ent]
-  (let [progress-output-file (:job/progress-output-file job-ent)]
+  [job-ent]
+  (let [{:keys [default-progress-regex-string environment log-level max-message-length progress-sample-interval-ms]}
+        (-> config :settings :executor)
+        progress-output-file (:job/progress-output-file job-ent)]
     (cond-> (assoc environment
               "EXECUTOR_LOG_LEVEL" log-level
               "EXECUTOR_MAX_MESSAGE_LENGTH" max-message-length
@@ -74,14 +78,14 @@
 
 (defn job->task-metadata
   "Takes a job entity, returns task metadata"
-  [db framework-id executor-config mesos-run-as-user job-ent task-id]
+  [db framework-id mesos-run-as-user job-ent task-id]
   (let [resources (util/job-ent->resources job-ent)
         container (util/job-ent->container db job-ent)
         ;; If the custom-executor attr isn't set, we default to using a custom
         ;; executor in order to support jobs submitted before we added this field
         custom-executor? (use-custom-executor? job-ent)
         cook-executor? (and (not container) ;;TODO support cook-executor in containers
-                            (use-cook-executor? job-ent executor-config))
+                            (use-cook-executor? job-ent))
         group-uuid (util/job-ent->group-uuid job-ent)
         environment (cond-> (assoc (util/job-ent->env job-ent)
                               "COOK_JOB_UUID" (-> job-ent :job/uuid str))
@@ -89,8 +93,9 @@
                             (:cpus resources) (assoc "COOK_JOB_CPUS" (-> resources :cpus str))
                             (:gpus resources) (assoc "COOK_JOB_GPUS" (-> resources :gpus str))
                             (:mem resources) (assoc "COOK_JOB_MEM_MB" (-> resources :mem str))
-                            cook-executor? (merge (build-executor-environment executor-config job-ent)))
+                            cook-executor? (merge (build-executor-environment job-ent)))
         labels (util/job-ent->label job-ent)
+        executor-config (-> config :settings :executor)
         command {:environment environment
                  :uris (cond-> (:uris resources [])
                                (and cook-executor? (get-in executor-config [:uri :value]))
@@ -135,9 +140,9 @@
 
 (defn TaskAssignmentResult->task-metadata
   "Organizes the info Fenzo has already told us about the task we need to run"
-  [db framework-id executor-config mesos-run-as-user ^TaskAssignmentResult task-result]
+  [db framework-id mesos-run-as-user ^TaskAssignmentResult task-result]
   (let [{:keys [job task-id] :as task-request} (.getRequest task-result)]
-    (merge (job->task-metadata db framework-id executor-config mesos-run-as-user job task-id)
+    (merge (job->task-metadata db framework-id mesos-run-as-user job task-id)
            {:hostname (.getHostname task-result)
             :ports-assigned (vec (sort (.getAssignedPorts task-result)))
             :task-request task-request})))

--- a/scheduler/src/cook/mesos/task.clj
+++ b/scheduler/src/cook/mesos/task.clj
@@ -55,11 +55,10 @@
    3. Either :job/executor is explicitly enabled
       Or: the job is a cook-executor candidate (see cook-executor-candidate?)."
   [job-ent]
-  (let [{:keys [command]} (-> config :settings :executor)]
-    (and (not (use-custom-executor? job-ent))
-         command
-         (or (= :executor/cook (:job/executor job-ent))
-             (cook-executor-candidate? job-ent)))))
+  (and (not (use-custom-executor? job-ent))
+       (-> config :settings :executor :command)
+       (or (= :executor/cook (:job/executor job-ent))
+           (cook-executor-candidate? job-ent))))
 
 (defn build-executor-environment
   "Build the environment for the cook executor."

--- a/scheduler/test/cook/test/mesos/scheduler.clj
+++ b/scheduler/test/cook/test/mesos/scheduler.clj
@@ -28,7 +28,8 @@
             [cook.mesos.scheduler :as sched]
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
-            [cook.test.testutil :refer (restore-fresh-database! create-dummy-group create-dummy-job create-dummy-instance init-offer-cache poll-until)]
+            [cook.test.testutil :refer [restore-fresh-database! create-dummy-group create-dummy-job
+                                        create-dummy-instance init-offer-cache poll-until setup]]
             [criterium.core :as crit]
             [datomic.api :as d :refer (q db)]
             [mesomatic.scheduler :as msched]
@@ -1531,10 +1532,11 @@
                                             user->quota (or user-quota {test-user {:count 10, :cpus 50, :mem 32768, :gpus 10}})
                                             mesos-run-as-user nil
                                             result (sched/handle-resource-offers!
-                                                     conn driver fenzo framework-id executor category->pending-jobs-atom mesos-run-as-user
+                                                     conn driver fenzo framework-id category->pending-jobs-atom mesos-run-as-user
                                                      user->usage user->quota num-considerable offers-chan offers rebalancer-reservation-atom)]
                                         (async/>!! offers-chan :end-marker)
                                         result))]
+    (setup :config {:executor executor})
 
     (testing "enough offers for all normal jobs"
       (let [num-considerable 10

--- a/scheduler/test/cook/test/simulator.clj
+++ b/scheduler/test/cook/test/simulator.clj
@@ -19,7 +19,7 @@
             [cook.mesos.mesos-mock :as mm]
             [cook.mesos.share :as share]
             [cook.mesos.util :as util]
-            [cook.test.testutil :refer (restore-fresh-database! poll-until)]
+            [cook.test.testutil :refer (restore-fresh-database! poll-until setup)]
             [datomic.api :as d]
             [plumbing.core :refer (map-vals map-keys map-from-vals)])
   (:import org.apache.curator.framework.CuratorFrameworkFactory
@@ -125,9 +125,9 @@
          trigger-chans# (or (:trigger-chans ~scheduler-config)
                             (c/make-trigger-chans rebalancer-config# progress-config# optimizer-config# task-constraints#))]
      (try
+       (setup :config {:executor executor-config#})
        (c/start-mesos-scheduler
          {:curator-framework curator-framework#
-          :executor-config executor-config#
           :fenzo-config fenzo-config#
           :framework-id framework-id#
           :get-mesos-utilization get-mesos-utilization#


### PR DESCRIPTION
If you haven't already, please see https://github.com/twosigma/Cook/pull/741 for context.

This PR builds on top of https://github.com/twosigma/Cook/pull/741 and shows what it looks like to remove the executor config argument from all of the call chains it's passed through. It also addresses the corresponding unit tests.